### PR TITLE
Added parsing of enabled protocols to the statusHandler

### DIFF
--- a/lib/rfxcom.js
+++ b/lib/rfxcom.js
@@ -159,7 +159,7 @@ RfxCom.prototype.statusHandler = function(data) {
     // Check which protocols are enabled
     for (var key in rfxcom.protocols) {
         var value = rfxcom.protocols[key];
-        if (msg[value['msg']] & value['bit']) {
+        if (msg[value["msg"]] & value["bit"]) {
             protocols.push(key);
         }
     }

--- a/test/rfxcom.spec.js
+++ b/test/rfxcom.spec.js
@@ -505,7 +505,7 @@ describe("RfxCom", function() {
                     expect(evt.cmnd).toBe(0x20);
                     expect(evt.receiverType).toBe("433.92MHz transceiver");
                     expect(evt.firmwareVersion).toBe(0x30);
-                    expect(evt.enabledProtocols).toEqual(['RSL', 'BYRONSX']);
+                    expect(evt.enabledProtocols).toEqual(["RSL", "BYRONSX"]);
                     done();
                 })
                 device.statusHandler([0, 1, 0x20, 0x53, 0x30, 0x30, 0, 0, 0, 0, 0, 0, 0])


### PR DESCRIPTION
Modification to the statusHandler, so that it extracts the enabled protocols.
Also added a test.

Going to use this, so that I can display/edit the enabled protocols in my webapp:
https://github.com/njh/node-rfxtx-manager

[apologies, this is just about the first JavaScript/Node I have written, so let me know if I am getting style wrong]
