### PR TITLE
serialport parser

### DIFF
--- a/lib/rfxcom.js
+++ b/lib/rfxcom.js
@@ -42,10 +42,10 @@ function RfxCom(device, options) {
             // Collect data
             data.push.apply(data, buffer);
             if (requiredBytes === 0) {
-                requiredBytes = buffer[0] + 1;
+                requiredBytes = data[0] + 1;
             }
             if (data.length >= requiredBytes) {
-                emitter.emit("data", data.slice(0, requiredBytes + 1));
+                emitter.emit("data", data.slice(0, requiredBytes));
                 data = data.slice(requiredBytes);
                 requiredBytes = 0;
             }


### PR DESCRIPTION
1/ emitter data is one byte larger
2/ required bytes is calculed on data variable and not on buffer variable.
