### PR TITLE
Change the way security1 device addreses are processed in the receive…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+Version 2.0.2
+-------------
+Change the way security1 device addreses are processed in the receive handler, to ensure they are compatible with the 
+transmitter.
+
+Version 2.0.1
+-------------
+
+Workarounds for newly-introduced serialport bugs
+
 Version 2.0.0
 -------------
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -409,6 +409,11 @@ exports.security = {
     PANIC: 6,
     END_PANIC: 7,
     IR: 8,
+    ARM_AWAY: 9,
+    ARM_AWAY_DELAYED: 10,
+    ARM_HOME: 11,
+    ARM_HOME_DELAYED: 12,
+    DISARM: 13,
     X10_DOOR_WINDOW_SENSOR: 0,
     X10_MOTION_SENSOR: 1,
     X10_SECURITY_REMOTE: 2

--- a/lib/rfxcom.js
+++ b/lib/rfxcom.js
@@ -1011,18 +1011,32 @@ class RfxCom extends EventEmitter {
         const
             subtype = data[0],
             seqnbr = data[1],
-            id = "0x" + RfxCom.dumpHex(data.slice(2, 5), false).join(""),
             deviceStatus = data[5] & ~0x80,
             batterySignalLevel = data[6],
             evt = {
                 subtype: subtype,
                 seqnbr: seqnbr,
-                id: id,
                 deviceStatus: deviceStatus,
                 batteryLevel: batterySignalLevel & 0x0f,
                 rssi: (batterySignalLevel >> 4) & 0xf,
                 tampered: data[5] & 0x80
             };
+        switch (subtype) {
+            case 0x00:
+            case 0x01:
+            case 0x02:
+                evt.id = "0x" + RfxCom.dumpHex([data[2], data[4]], false).join("");
+                break;
+
+            case 0x03:
+            case 0x09:
+                evt.id = "0x" + RfxCom.dumpHex(data.slice(2, 4), false).join("");
+                break;
+
+            default:
+                evt.id = "0x" + RfxCom.dumpHex(data.slice(2, 5), false).join("");
+                break;
+        }
         this.emit("security1", evt, packetType);
     };
 


### PR DESCRIPTION
… handler, to ensure they are compatible with the transmitter.

Add X10 security command/status definitions