### PR TITLE
extend the unitcode limit on RFY subtype

### DIFF
--- a/lib/rfy.js
+++ b/lib/rfy.js
@@ -46,7 +46,7 @@ class Rfy extends Transmitter {
         if (id.value < 1 || id.value > 0xfffff) {
             Transmitter.addressError(id);
         }
-        if ((this.isSubtype("RFY") && (unitCode < 0x00 || unitCode > 0x04)) ||
+        if ((this.isSubtype("RFY") && (unitCode < 0x00 || unitCode > 0x0f)) ||
             (this.isSubtype("RFYEXT") && (unitCode < 0x00 || unitCode > 0x0f)) ||
             (this.isSubtype("ASA") && (unitCode < 0x01 || unitCode > 0x05))) {
             throw new Error("Invalid unit code " + parts[1]);


### PR DESCRIPTION
The rfy subtype accepts unitcodes at least up to 0x0b (tested and working on my setup), I think it should be up to 0x0f.