### PR TITLE
Moved pipe function to also pipe for faked serial ports

### DIFF
--- a/lib/rfxcom.js
+++ b/lib/rfxcom.js
@@ -291,6 +291,10 @@ class RfxCom extends EventEmitter {
                 lock: false,
                 autoOpen: false
             });
+        }
+
+        // Make sure all data is piped to the parser (also for faked serialports)
+        if (typeof self.serialport.pipe === "function") {
             self.serialport.pipe(self.parser);
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rfxcom",
-  "version": "2.5.0",
+  "version": "2.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rfxcom",
-      "version": "2.5.0",
+      "version": "2.6.2",
       "license": "MIT",
       "dependencies": {
         "date-format": "^4.0.14",

--- a/test/helper.js
+++ b/test/helper.js
@@ -8,6 +8,7 @@ class FakeSerialPort extends events.EventEmitter {
         this.bytesWritten = [];
         this.flushed = false;
         this.isOpen = true;
+        this.pipeDestination = undefined;
     }
 
     write(buffer, callback) {
@@ -17,6 +18,10 @@ class FakeSerialPort extends events.EventEmitter {
             callback();
         }
     };
+
+    pipe(destination) {
+        this.pipeDestination = destination;
+    }
 
     flush(callback) {
         this.flushed = true;

--- a/test/rfxcom.spec.js
+++ b/test/rfxcom.spec.js
@@ -640,6 +640,14 @@ describe("RfxCom", function() {
                 });
             });
         });
+        it(".open should pipe data from the fake serialport to the parser", function() {
+            const fakeSerialPort = new FakeSerialPort(),
+                device = new rfxcom.RfxCom("/", {
+                    port: fakeSerialPort
+                });
+            device.open();
+            expect(fakeSerialPort.pipeDestination).toBe(device.parser);
+        });
         describe(".bytesToUint48", function() {
             it("should convert a sequence of 6 bytes to a longint", function() {
                 expect(rfxcom.RfxCom.bytesToUint48([0xF1, 0x27, 0xba, 0x67, 0x28, 0x97])).toBe(265152933341335);


### PR DESCRIPTION
The faking of the serial port allows me to use a mocked serial port using a socket, allowing me to use the newer RFX-433EMC device over WiFi. The only thing that does not work however, is the piping of the data to the parser. This is because the pipe function is not called on the mocked serial port. This PR moves that pipe function, allowing me to fully mock the serialport.

<details>

<summary>Example of the tcp serial port</summary>

```javascript
class TcpSerialPort extends EventEmitter {
    constructor(host, options = {}) {
        super()
        this.host = host
        this.port = options.port || 10001
        this.socket = null
        this.isOpen = false
    }

    open(callback) {
        this.socket = net.connect(this.port, this.host, () => {
            this.isOpen = true
            this.emit('open')
            callback && callback(null)
        })
        this.emit('socket_created', this.socket)

        this.socket.on('data', (data) => {
            this.emit('data', data)
        })
        this.socket.on('close', () => {
            this.isOpen = false
            this.emit('close')
        })
        this.socket.on('error', (err) => {
            this.emit('error', err)
            callback && callback(err)
        })
    }

    write(data, callback) {
        if (!this.isOpen) {
            return callback && callback(new Error('Connection is not open'))
        }
        
        // Convert Array to Buffer if necessary
        if (!Buffer.isBuffer(data)) {
            data = Buffer.from(data)
        }

        this.socket.write(data, callback)
    }

    pipe(destination, options) {
        if (!this.isOpen || !this.socket) {
            throw new Error('Connection is not open')
        }
        return this.socket.pipe(destination, options)
    }

    close(callback) {
        if (this.socket) {
            this.socket.end(() => {
                this.isOpen = false
                callback && callback(null)
            })
        } else {
            callback && callback(new Error('Connection is not open'))
        }
    }

    flush(callback) {
        callback && callback()
    }

    set(_options, callback) {
        callback && callback(null)
    }

    get path() {
        return `${this.host}:${this.port}`
    }
}
```

</details>